### PR TITLE
Don't throw nested exception from dtor of Mock object

### DIFF
--- a/googlemock/include/gmock/gmock-spec-builders.h
+++ b/googlemock/include/gmock/gmock-spec-builders.h
@@ -1467,7 +1467,8 @@ class FunctionMockerBase : public UntypedFunctionMockerBase {
   virtual ~FunctionMockerBase()
         GTEST_LOCK_EXCLUDED_(g_gmock_mutex) {
     MutexLock l(&g_gmock_mutex);
-    VerifyAndClearExpectationsLocked();
+    if (!std::uncaught_exception())
+        VerifyAndClearExpectationsLocked();
     Mock::UnregisterLocked(this);
     ClearDefaultActionsLocked();
   }


### PR DESCRIPTION
Fix of #206 